### PR TITLE
Initial support for multiple aurora versions

### DIFF
--- a/AuroraPatch/AuroraPatch.csproj
+++ b/AuroraPatch/AuroraPatch.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -44,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuroraVersion.cs" />
     <Compile Include="Patch.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -56,6 +61,7 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -65,6 +71,11 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="versions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AuroraPatch/AuroraVersion.cs
+++ b/AuroraPatch/AuroraVersion.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace AuroraPatch
+{
+    public class AuroraVersion
+    {
+        public Version Version { get; }
+        
+        public string Checksum { get; }
+        
+        public string FormType { get; }
+
+        public AuroraVersion(Version version, string checksum, string formType)
+        {
+            Version = version;
+            Checksum = checksum;
+            FormType = formType;
+        }
+
+        public bool CompareTo(AuroraVersion other)
+        {
+            return Version.Equals(other.Version) && Checksum.Equals(other.Checksum);
+        }
+    }
+}

--- a/AuroraPatch/packages.config
+++ b/AuroraPatch/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
+</packages>

--- a/AuroraPatch/versions.json
+++ b/AuroraPatch/versions.json
@@ -1,0 +1,20 @@
+﻿[
+  {
+    // Vanilla Aurora
+    "version": "1.9.3",
+    "checksum": "rTJo4i",
+    "formType": "jl"
+  },
+  {
+    // Cleaned Aurora (de4dot)
+    "version": "1.9.3",
+    "checksum": "8obaQg",
+    "formType": "TacticalMap"
+  },
+  {
+    // AuroraMod
+    "version": "1.9.3",
+    "checksum": "xVQcy1",
+    "formType": "TacticalMap"
+  }
+]


### PR DESCRIPTION
This reuses checksum calc logic from the loaded, but doesn't have registry.

I have tested it with 3 Aurora.exe versions - AuroraMod, Vanilla Aurora, and Cleaned Aurora (used de4dot)