### PR TITLE
No more AuroraMod dependency, many helper methods for patch creators

### DIFF
--- a/AuroraPatch/AuroraPatch.csproj
+++ b/AuroraPatch/AuroraPatch.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TypeManager.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Patch.cs" />
     <Compile Include="Program.cs" />

--- a/AuroraPatch/Patch.cs
+++ b/AuroraPatch/Patch.cs
@@ -1,31 +1,49 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
 
 namespace AuroraPatch
 {
+    /// <summary>
+    /// Abstract representation of a Aurora Patch.
+    /// Every patch needs to implement the Start() abstract void method.
+    /// All patches have access to the TypeManager object which will be
+    /// populated by the time Start() is executed.
+    /// </summary>
     public abstract class Patch
     {
-        private Form TacticalMap { get; set; } = null;
+        protected TypeManager TypeManager;
 
-        internal void Run(Form map)
+        /// <summary>
+        /// The main patch program is responsible for executing the Run method
+        /// and injecting the TypeManager object to every patch implementation.
+        /// </summary>
+        /// <param name="typeManager"></param>
+        internal void Run(TypeManager typeManager)
         {
-            TacticalMap = map;
-            Start(TacticalMap);
+            TypeManager = typeManager;
+            Start();
         }
 
-        protected abstract void Start(Form map);
+        protected abstract void Start();
 
+        /// <summary>
+        /// Invoke an action on the main Aurora UI thread.
+        /// </summary>
+        /// <param name="action"></param>
         protected void InvokeOnUIThread(Action action)
         {
-            TacticalMap.Invoke(action);
+            TypeManager.GetFormInstance(AuroraFormType.TacticalMap).Invoke(action);
         }
 
+        /// <summary>
+        /// Invoke a parametarized delegate method on the main Aurora UI thread.
+        /// Allows for capturing a return value.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
         protected object InvokeOnUIThread(Delegate method, params object[] args)
         {
-            return TacticalMap.Invoke(method, args);
+            return TypeManager.GetFormInstance(AuroraFormType.TacticalMap).Invoke(method, args);
         }
     }
 }

--- a/AuroraPatch/TypeManager.cs
+++ b/AuroraPatch/TypeManager.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace AuroraPatch
+{
+    /// <summary>
+    /// Represents the various Aurora form types accessible by 3rd party patches.
+    /// </summary>
+    public enum AuroraFormType
+    {
+        TacticalMap,
+        Economics,
+    }
+
+    /// <summary>
+    /// Helper class to interacting with the various Aurora assembly Types.
+    /// </summary>
+    public class TypeManager
+    {
+        private Assembly AuroraAssembly;
+        private Logger logger;
+        private ConcurrentDictionary<AuroraFormType, Type> AuroraFormTypes = new ConcurrentDictionary<AuroraFormType, Type>();
+        private ConcurrentDictionary<AuroraFormType, Form> AuroraFormTypeInstances = new ConcurrentDictionary<AuroraFormType, Form>();
+        private BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        public TypeManager(Assembly assembly, Logger logger)
+        {
+            AuroraAssembly = assembly;
+            this.logger = logger;
+            FindFormTypes();
+        }
+
+        /// <summary>
+        /// Helper method to pull out Types from the Aurora assembly.
+        /// Can supply various filters.
+        /// Useful when obfuscation makes it difficult to find a Type by name.
+        /// 3rd party patches should use GetFormType(AuroraFormType) instead whenever possible as it implements caching.
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="name"></param>
+        /// <param name="baseType"></param>
+        /// <param name="minMembers"></param>
+        /// <param name="maxMembers"></param>
+        /// <param name="minProperties"></param>
+        /// <param name="maxProperties"></param>
+        /// <param name="minFields"></param>
+        /// <param name="maxFields"></param>
+        /// <param name="isPublic"></param>
+        /// <param name="isNotPublic"></param>
+        /// <param name="isAbstract"></param>
+        /// <param name="isInterface"></param>
+        /// <param name="isClass"></param>
+        /// <param name="isEnum"></param>
+        /// <param name="minPropertyTypes"></param>
+        /// <param name="maxPropertyTypes"></param>
+        /// <param name="minFieldTypes"></param>
+        /// <param name="maxFieldTypes"></param>
+        /// <returns></returns>
+        public IEnumerable<Type> GetAuroraTypes(
+            string name = null,
+            Type baseType = null,
+            int? minMembers = null,
+            int? maxMembers = null,
+            int? minProperties = null,
+            int? maxProperties = null,
+            int? minFields = null,
+            int? maxFields = null,
+            bool? isPublic = null,
+            bool? isNotPublic = null,
+            bool? isAbstract = null,
+            bool? isInterface = null,
+            bool? isClass = null,
+            bool? isEnum = null,
+            IEnumerable<Tuple<Type, int>> minPropertyTypes = null,
+            IEnumerable<Tuple<Type, int>> maxPropertyTypes = null,
+            IEnumerable<Tuple<Type, int>> minFieldTypes = null,
+            IEnumerable<Tuple<Type, int>> maxFieldTypes = null)
+        {
+            if (name != null) return new List<Type> { AuroraAssembly.GetType(name) };
+            IEnumerable<Type> types = AuroraAssembly.GetTypes().ToList();
+            if (baseType != null) types = types.Where(t => t.BaseType.Equals(baseType));
+            if (minMembers != null) types = types.Where(t => t.GetMembers().Length >= minMembers);
+            if (maxMembers != null) types = types.Where(t => t.GetMembers().Length <= maxMembers);
+            if (minProperties != null) types = types.Where(t => t.GetProperties().Length >= minProperties);
+            if (maxProperties != null) types = types.Where(t => t.GetProperties().Length <= maxProperties);
+            if (minFields != null) types = types.Where(t => t.GetFields().Length >= minFields);
+            if (maxFields != null) types = types.Where(t => t.GetFields().Length <= maxFields);
+            if (isPublic != null) types = types.Where(t => t.IsPublic);
+            if (isNotPublic != null) types = types.Where(t => t.IsNotPublic);
+            if (isAbstract != null) types = types.Where(t => t.IsAbstract);
+            if (isInterface != null) types = types.Where(t => t.IsInterface);
+            if (isClass != null) types = types.Where(t => t.IsClass);
+            if (isEnum != null) types = types.Where(t => t.IsEnum);
+            if (minPropertyTypes != null)
+            {
+                foreach (Tuple<Type, int> minPropertyTuple in minPropertyTypes)
+                {
+                    types = types.Where(t =>
+                    {
+                        var properties = t.GetProperties(DefaultBindingFlags)
+                            .Where(p => p.PropertyType.Equals(minPropertyTuple.Item1));
+                        return properties.Count() >= minPropertyTuple.Item2;
+                    });
+                }
+            }
+            if (maxPropertyTypes != null)
+            {
+                foreach (Tuple<Type, int> maxPropertyTuple in maxPropertyTypes)
+                {
+                    types = types.Where(t =>
+                    {
+                        var properties = t.GetProperties(DefaultBindingFlags)
+                            .Where(p => p.PropertyType.Equals(maxPropertyTuple.Item1));
+                        return properties.Count() <= maxPropertyTuple.Item2;
+                    });
+                }
+            }
+            if (minFieldTypes != null)
+            {
+                foreach (Tuple<Type, int> minFieldTuple in minFieldTypes)
+                {
+                    types = types.Where(t =>
+                    {
+                        var fields = t.GetFields(DefaultBindingFlags)
+                            .Where(f => f.FieldType.Equals(minFieldTuple.Item1));
+                        return fields.Count() >= minFieldTuple.Item2;
+                    });
+                }
+            }
+            if (maxFieldTypes != null)
+            {
+                foreach (Tuple<Type, int> maxFieldTuple in maxFieldTypes)
+                {
+                    types = types.Where(t =>
+                    {
+                        var fields = t.GetFields(DefaultBindingFlags)
+                            .Where(f => f.FieldType.Equals(maxFieldTuple.Item1));
+                        return fields.Count() <= maxFieldTuple.Item2;
+                    });
+                }
+            }
+            return types;
+        }
+
+        /// <summary>
+        /// Find the TacticalMap Form type and populate our AuroraFormTypes dictionary.
+        /// This can be a bit tricky due to the obfuscation. We're going in blind and counting buttons/checkboxes.
+        /// As of May 3rd 2021 (Aurora 1.13), the TacticalMap had 66 buttons and 68 checkboxes so that's our signature.
+        /// We got a bit of wiggle room as we're looking for a Form object with anywhere between 60 and 80 of each.
+        /// </summary>
+        private void FindTacticalMapFormType()
+        {
+            IEnumerable<Type> types = GetAuroraTypes(
+                baseType: typeof(Form),
+                minFieldTypes: new List<Tuple<Type, int>> { 
+                    new Tuple<Type, int>(typeof(Button), 60),
+                    new Tuple<Type, int>(typeof(CheckBox), 60)
+                },
+                maxFieldTypes: new List<Tuple<Type, int>> { 
+                    new Tuple<Type, int>(typeof(Button), 80),
+                    new Tuple<Type, int>(typeof(CheckBox), 80)
+                }
+            );
+            if (types.Count() < 1)
+            {
+                logger.LogError("TacticalMap Form type could not be identified");
+                return;
+            }
+            if (types.Count() > 1)
+            {
+                logger.LogError("Found " + types.Count() + " TacticalMap Form types - attempting to use the first one");
+            }
+            var type = types.First();
+            logger.LogDebug("TacticalMap Type found: " + type.Name);
+            AuroraFormTypes[AuroraFormType.TacticalMap] = type;
+        }
+
+        /// <summary>
+        /// Find the Economics Form type and populate our AuroraFormTypes dictionary.
+        /// This can be a bit tricky due to the obfuscation. We're going in blind and counting buttons/checkboxes.
+        /// As of May 3rd 2021 (Aurora 1.13), the Economics Form had 73 buttons and 12 checkboxes so that's our signature.
+        /// We got a bit of wiggle room as we're looking for a Form object with anywhere between 70 to 80 buttons and
+        /// 10 to 15 checkboxes.
+        /// </summary>
+        private void FindEconomicsFormType()
+        {
+            IEnumerable<Type> types = GetAuroraTypes(
+                baseType: typeof(Form),
+                minFieldTypes: new List<Tuple<Type, int>> { 
+                    new Tuple<Type, int>(typeof(Button), 70),
+                    new Tuple<Type, int>(typeof(CheckBox), 10)
+                },
+                maxFieldTypes: new List<Tuple<Type, int>> { 
+                    new Tuple<Type, int>(typeof(Button), 80),
+                    new Tuple<Type, int>(typeof(CheckBox), 15)
+                }
+            );
+            if (types.Count() < 1)
+            {
+                logger.LogError("Economics Form type could not be identified");
+                return;
+            }
+            if (types.Count() > 1)
+            {
+                logger.LogError("Found " + types.Count() + " Economics Form types - attempting to use the first one");
+            }
+            var type = types.First();
+            logger.LogDebug("Economics Type found: " + type.Name);
+            AuroraFormTypes[AuroraFormType.Economics] = type;
+        }
+
+        /// <summary>
+        /// Finds all supported Aurora Form types and populates the AuroraFormTypes static dictionary instance.
+        /// </summary>
+        private void FindFormTypes()
+        {
+            FindTacticalMapFormType();
+            FindEconomicsFormType();
+        }
+
+        /// <summary>
+        /// Public interface to access common/cached Form types pulled from the Aurora assembly.
+        /// </summary>
+        /// <param name="auroraFormType"></param>
+        /// <returns></returns>
+        public Type GetFormType(AuroraFormType auroraFormType)
+        {
+            if (AuroraFormTypes.ContainsKey(auroraFormType))
+            {
+                return AuroraFormTypes[auroraFormType];
+            }
+            logger.LogWarning("Could not find Aurora Form " + Enum.GetName(typeof(AuroraFormType), auroraFormType));
+            return null;
+        }
+
+        /// <summary>
+        /// Public interface to access a cached instance of a particular Aurora Form.
+        /// </summary>
+        /// <param name="auroraFormType"></param>
+        /// <returns></returns>
+        public Form GetFormInstance(AuroraFormType auroraFormType)
+        {
+            switch (auroraFormType)
+            {
+                case AuroraFormType.TacticalMap:
+                    return GetTacticalMapFormInstance();
+                default:
+                    logger.LogWarning("No Form instance available for " + Enum.GetName(typeof(AuroraFormType), auroraFormType));
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Helper method that instantiates a TacticalMap Form instance and returns it.
+        /// </summary>
+        private Form GetTacticalMapFormInstance()
+        {
+            if (AuroraFormTypeInstances.ContainsKey(AuroraFormType.TacticalMap))
+            {
+                logger.LogDebug("Found existing TacticalMap Form instance");
+                return AuroraFormTypeInstances[AuroraFormType.TacticalMap];
+            }
+            var type = GetFormType(AuroraFormType.TacticalMap);
+            if (type != null)
+            {
+                logger.LogInfo("Creating TacticalMap Form instance");
+                var instance = (Form)Activator.CreateInstance(type);
+                AuroraFormTypeInstances[AuroraFormType.TacticalMap] = instance;
+                return instance;
+            }
+            logger.LogError("Failed to get TacticalMap Form instance");
+            return null;
+        }
+
+        /// <summary>
+        /// Helper method to pull out methods from a Type.
+        /// Can supply various filters.
+        /// Useful when obfuscation makes it difficult to find a method by name.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="name"></param>
+        /// <param name="minParameters"></param>
+        /// <param name="maxParameters"></param>
+        /// <param name="minStackSize"></param>
+        /// <param name="maxStackSize"></param>
+        /// <param name="minLocalVariables"></param>
+        /// <param name="maxLocalVariables"></param>
+        /// <param name="minBodySize"></param>
+        /// <param name="maxBodySize"></param>
+        /// <param name="isAbstract"></param>
+        /// <param name="isVirtual"></param>
+        /// <param name="isStatic"></param>
+        /// <param name="isConstructor"></param>
+        /// <param name="isPrivate"></param>
+        /// <param name="isPublic"></param>
+        /// <param name="returnType"></param>
+        /// <param name="parameterTypes"></param>
+        /// <param name="localVariableTypes"></param>
+        /// <returns></returns>
+        public IEnumerable<MethodInfo> GetTypeMethods(
+            Type type,
+            string name = null,
+            int? minParameters = null,
+            int? maxParameters = null,
+            int? minBodySize = null,
+            int? maxBodySize = null,
+            int? minStackSize = null,
+            int? maxStackSize = null,
+            int? minLocalVariables = null,
+            int? maxLocalVariables = null,
+            bool? isAbstract = null,
+            bool? isVirtual = null,
+            bool? isStatic = null,
+            bool? isConstructor = null,
+            bool? isPrivate = null,
+            bool? isPublic = null,
+            Type returnType = null,
+            IEnumerable<Type> parameterTypes = null,
+            IEnumerable<Type> localVariableTypes = null)
+        {
+            if (name != null) return new List<MethodInfo> { type.GetMethod(name, DefaultBindingFlags) };
+            IEnumerable<MethodInfo> methods = type.GetMethods(DefaultBindingFlags);
+            if (minParameters != null) methods = methods.Where(m => m.GetParameters().Count() >= minParameters);
+            if (maxParameters != null) methods = methods.Where(m => m.GetParameters().Count() <= maxParameters);
+            if (minBodySize != null) methods = methods.Where(m => m.GetMethodBody().GetILAsByteArray().Length >= minBodySize);
+            if (maxBodySize != null) methods = methods.Where(m => m.GetMethodBody().GetILAsByteArray().Length <= maxBodySize);
+            if (minStackSize != null) methods = methods.Where(m => m.GetMethodBody().MaxStackSize >= minStackSize);
+            if (maxStackSize != null) methods = methods.Where(m => m.GetMethodBody().MaxStackSize <= maxStackSize);
+            if (minLocalVariables != null) methods = methods.Where(m => m.GetMethodBody().LocalVariables.Count() >= minLocalVariables);
+            if (maxLocalVariables != null) methods = methods.Where(m => m.GetMethodBody().LocalVariables.Count() <= maxLocalVariables);
+            if (isAbstract != null) methods = methods.Where(m => m.IsAbstract);
+            if (isVirtual != null) methods = methods.Where(m => m.IsVirtual);
+            if (isStatic != null) methods = methods.Where(m => m.IsStatic);
+            if (isConstructor != null) methods = methods.Where(m => m.IsConstructor);
+            if (isPrivate != null) methods = methods.Where(m => m.IsPrivate);
+            if (isPublic != null) methods = methods.Where(m => m.IsPublic);
+            if (returnType != null) methods = methods.Where(m => m.ReturnType.Equals(returnType));
+            if (parameterTypes != null)
+            {
+                foreach (Type parameterType in parameterTypes)
+                {
+                    methods = methods.Where(m =>
+                    {
+                        var parameters = m.GetParameters().Where(p => p.ParameterType.Equals(parameterType));
+                        return parameters.Count() > 0;
+                    });
+                }
+            }
+            if (localVariableTypes != null)
+            {
+                foreach (Type localVariableType in localVariableTypes)
+                {
+                    methods = methods.Where(m =>
+                    {
+                        var localVariables = m.GetMethodBody().LocalVariables.Where(lv => lv.LocalType.Equals(localVariableType));
+                        return localVariables.Count() > 0;
+                    });
+                }
+            }
+            return methods;
+        }
+
+        /// <summary>
+        /// Helper method to pull out fields of a particular type from a parent type.
+        /// Useful when obfuscation makes it difficult to find a field by name.
+        /// </summary>
+        /// <typeparam name="T">The field type requested.</typeparam>
+        /// <typeparam name="U">The parent type.</typeparam>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public IEnumerable<T> GetTypeFields<T, U>(U type)
+        {
+            List<T> fields = new List<T>();
+            foreach (FieldInfo field in type.GetType().GetFields(DefaultBindingFlags))
+            {
+                if (field.FieldType.Equals(typeof(T))) fields.Add((T)field.GetValue(type));
+            }
+            return fields;
+        }
+    }
+}

--- a/ExamplePatch/ExamplePatch.cs
+++ b/ExamplePatch/ExamplePatch.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
+using System.Reflection;
 using System.Windows.Forms;
+using System.Collections.Generic;
 using HarmonyLib;
 
 using AuroraPatch;
@@ -11,86 +12,50 @@ namespace ExamplePatch
 {
     public class ExamplePatch : AuroraPatch.Patch
     {
-        private Form TacticalMap { get; set; } = null;
-
-        protected override void Start(Form map)
+        protected override void Start()
         {
             Program.logger.LogInfo("Loading ExamplePatch...");
 
-            // save a reference to the tactical map
-            TacticalMap = map;
+            // Save a reference to the tactical map.
+            var map = TypeManager.GetFormInstance(AuroraFormType.TacticalMap);
 
-            // get the checksum of the exe you're patching
+            // Get the checksum of the exe you're patching.
             var checksum = Program.AuroraChecksum;
 
-            // get its dirrectory
+            // Get its directory.
             var dir = Program.AuroraExecutableDirectory;
 
-            // invoke arbitrary code on Aurora's UI thread
+            // Invoke arbitrary code on Aurora's UI thread.
             var action = new Action(() => MessageBox.Show("Example patch loaded!"));
             InvokeOnUIThread(action);
 
-            // Harmony support
+            // Harmony support example.
+            // Find and patch the Economics Form's InitializeComponent obfuscated method.
+            // As of Aurora 1.13, that method has no parameters, a void return type, and a body size of 627.
             var harmony = new Harmony("some.id");
-            var type = map.GetType().Assembly.GetTypes().Single(t => t.Name == "Economics");
-            var original = AccessTools.Method(type, "InitializeComponent");
+            var type = TypeManager.GetFormType(AuroraFormType.Economics);
+            var methods = TypeManager.GetTypeMethods(type, maxParameters: 0, returnType: typeof(void), minBodySize: 600, maxBodySize: 700);
+            var original = AccessTools.Method(type, methods.First().Name);
             var prefix = SymbolExtensions.GetMethodInfo(() => PatchMethod());
             harmony.Patch(original, new HarmonyMethod(prefix));
 
-            // Press the 5 day increment button 10 times in a row
-            Button button5d = null;
-
-            foreach (var field in map.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-            {
-                if (field.FieldType == typeof(Button))
-                {
-                    var button = field.GetValue(map) as Button;
-                    if (button.Name == "cmdIncrement5D")
-                    {
-                        button5d = button;
-                        break;
-                    }
-                }
-            }
-
-            if (button5d == null)
-            {
-                throw new Exception("button5d not found");
-            }
-
+            // Press the 5 day increment button 10 times in a row.
+            IEnumerable<Button> buttons = TypeManager.GetTypeFields<Button, Form>(map);
+            Button button5d = buttons.Single(b => b.Name == "cmdIncrement5D");
             for (int i = 0; i < 10; i++)
             {
                 action = new Action(() => button5d.PerformClick());
                 InvokeOnUIThread(action);
             }
 
-            // Add an event handler to pressing the 30d button
-            Button button30d = null;
-
-            foreach (var field in map.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-            {
-                if (field.FieldType == typeof(Button))
-                {
-                    var button = field.GetValue(map) as Button;
-                    if (button.Name == "cmdIncrement30D")
-                    {
-                        button30d = button;
-                        break;
-                    }
-                }
-            }
-
-            if (button30d == null)
-            {
-                throw new Exception("button30d not found");
-            }
-
+            // Add an event handler to pressing the 30d button.
+            Button button30d = buttons.Single(b => b.Name == "cmdIncrement30D");
             action = new Action(() => button30d.Click += Button30D);
             InvokeOnUIThread(action);
 
             Program.logger.LogInfo("ExamplePatch loaded successfully");
 
-            // Patch.Start is run on its own background thread, no need to return
+            // Patch.Start is run on its own background thread, no need to return.
             while (true)
             {
                 Thread.Sleep(15 * 60 * 1000);
@@ -107,7 +72,7 @@ namespace ExamplePatch
 
         private static void Button30D(object sender, EventArgs e)
         {
-            // ui event handlers are always run on the ui thread
+            // UI event handlers are always run on the ui thread.
             MessageBox.Show("You've pressed the 30d increment button");
         }
     }


### PR DESCRIPTION
AuroraMod isn't maintained for the forseable future - removing it's dependency on the example patch.
Putting in some legwork to make things easier on the patch creators.
Results in more code to maintain but I think the tradeoff is worth it.
Nice to be able to call methods like this:

            var type = TypeManager.GetFormType(AuroraFormType.Economics);
            var methods = TypeManager.GetTypeMethods(type, maxParameters: 0, returnType: typeof(void), minBodySize: 600, maxBodySize: 700);

And this:

            var buttons = TypeManager.GetTypeFields<Button, Form>(map);
            Button button5d = buttons.Single(b => b.Name == "cmdIncrement5D");
