### PR TITLE
changed the patch form so that closing it no longer kills the game

### DIFF
--- a/AuroraPatch/AuroraPatchForm.Designer.cs
+++ b/AuroraPatch/AuroraPatchForm.Designer.cs
@@ -98,6 +98,11 @@ namespace AuroraPatch
             this.ResumeLayout(false);
             this.PerformLayout();
 
+            //
+            // Upon closing the window the application doesn't stop
+            //
+            this.FormClosing += HideNotClose;
+
         }
 
         #endregion

--- a/AuroraPatch/AuroraPatchForm.cs
+++ b/AuroraPatch/AuroraPatchForm.cs
@@ -11,6 +11,17 @@ namespace AuroraPatch
         private readonly Loader Loader;
         private readonly List<Patch> Patches;
 
+        private void HideNotClose(object sender, FormClosingEventArgs e)
+        {
+            // If Aurora hasn't been started yet (indicated by the "started" flag in Loader class), closing the window should kill the entire application, not only remove the window.
+            if (e.CloseReason == CloseReason.UserClosing && Loader.started)
+            {
+                e.Cancel = true;
+                ((Control)sender).Hide();
+            }
+            if (e.CloseReason == CloseReason.UserClosing && !Loader.started) Environment.Exit(0);
+        }
+
         internal AuroraPatchForm(Loader loader) : base()
         {
             InitializeComponent();

--- a/AuroraPatch/AuroraPatchForm.cs
+++ b/AuroraPatch/AuroraPatchForm.cs
@@ -14,12 +14,13 @@ namespace AuroraPatch
         private void HideNotClose(object sender, FormClosingEventArgs e)
         {
             // If Aurora hasn't been started yet (indicated by the "started" flag in Loader class), closing the window should kill the entire application, not only remove the window.
-            if (e.CloseReason == CloseReason.UserClosing && Loader.started)
+            if (e.CloseReason == CloseReason.UserClosing && Loader.Started)
             {
                 e.Cancel = true;
                 ((Control)sender).Hide();
+                Loader.AuroraPatchClosed = true;
             }
-            if (e.CloseReason == CloseReason.UserClosing && !Loader.started) Environment.Exit(0);
+            if (e.CloseReason == CloseReason.UserClosing && !Loader.Started) Environment.Exit(0);
         }
 
         internal AuroraPatchForm(Loader loader) : base()

--- a/AuroraPatch/Loader.cs
+++ b/AuroraPatch/Loader.cs
@@ -18,7 +18,8 @@ namespace AuroraPatch
         internal readonly List<Patch> LoadedPatches = new List<Patch>();
         internal volatile Assembly AuroraAssembly = null;
         internal volatile Form TacticalMap = null;
-        internal bool started = false;
+        internal bool Started = false;
+        internal bool AuroraPatchClosed = false;
 
         internal Loader(string exe, string checksum)
         {
@@ -176,7 +177,7 @@ namespace AuroraPatch
 
             // At this point Aurora is definitely opened, so "started" flag needs to be set to properly to indicate that from now on close button shall not terminate the application, but only hide form.
             // Start monitoring Aurora, if the game is closed the application will also terminate.
-            started = true;
+            Started = true;
             Thread thread = new Thread(MonitorAuroraProcess);
             thread.Start();
         }
@@ -188,7 +189,7 @@ namespace AuroraPatch
             while (true)
             {
                 // Close AuroraPatch if tactical map is not visible or null.
-                if (TacticalMap is null || !TacticalMap.Visible)
+                if ((TacticalMap is null || !TacticalMap.Visible) && AuroraPatchClosed)
                 {
                     Program.Logger.LogInfo("Aurora process not found, closing application");
                     Environment.Exit(0);


### PR DESCRIPTION
Changed the way AuroraPatch config window is handled to make it behave like the config from AuroraMod - after launching the game, closing the patch window will no longer terminate the app, allowing for the game to run. In such case the process will end only after Aurora has been closed.