### PR TITLE
Use main Aurora icon for tactical map form

### DIFF
--- a/AuroraPatch/Loader.cs
+++ b/AuroraPatch/Loader.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace AuroraPatch
 {
@@ -218,7 +219,11 @@ namespace AuroraPatch
 
                 Program.Logger.LogInfo($"TacticalMap found: {map.Name}");
 
-                return (Form)Activator.CreateInstance(map);
+                Form mapForm = (Form)Activator.CreateInstance(map);
+
+                mapForm.Icon = Icon.ExtractAssociatedIcon(AuroraExecutablePath);
+
+                return mapForm;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
If you launch AuroraPatch -> Aurora you will have a default taskbar icon from AuroraPatch. If you then close AuroraPatch with Aurora still running you still have this default icon. I have modified to initialize tactical map form icon with default Aurora.exe resource icon. 

Before:
![before](https://user-images.githubusercontent.com/433527/119128325-31224400-ba3e-11eb-8d7c-dba85948a219.png)

After:
![after](https://user-images.githubusercontent.com/433527/119128341-35e6f800-ba3e-11eb-9fb1-b151ea1dfe93.png)

It will only change to this icon when you close AuroraPatch but leave Aurora running. Let me know if you think there is a better way to handle this.