### PR TITLE
fixes issues with decimal seperators for non en-GB users

### DIFF
--- a/AuroraPatch/Program.cs
+++ b/AuroraPatch/Program.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using System.Security.Cryptography;
 using System.Collections.Generic;
 using System.Linq;
+using System.Globalization;
 
 namespace AuroraPatch
 {
@@ -27,6 +28,10 @@ namespace AuroraPatch
             bool launch = args.Contains("-launch");
             
             var exe = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Aurora.exe");
+
+            var culture = CultureInfo.CreateSpecificCulture("en-GB");
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
 
             // Handle Aurora.exe path argument (skip -launch when looking for exe path)
             var nonConfigArgs = args.Where(arg => arg != "-launch").ToArray();


### PR DESCRIPTION
Aurora 2.7x changed how decimal seperators are handled.
Causing an issue when running Aurora with AuroraPatch using a non en-GB system(any using , instead of .)
The fix in Aurora seems to be overwritten by AuroraPatch, this forces aurorapatch to work as en-GB fixing the issue